### PR TITLE
Add CI: fpm.yml

### DIFF
--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -1,0 +1,57 @@
+name: fpm
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        gcc_v: [10] # Version of GFortran we want to use.
+        include:
+        - os: ubuntu-latest
+          os-arch: linux-x86_64
+
+        - os: macos-latest
+          os-arch: macos-x86_64
+
+        - os: windows-latest
+          os-arch: windows-x86_64
+            # Windows GFortran Version: 8.1
+
+    env:
+      FC: gfortran
+      GCC_V: ${{ matrix.gcc_v }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+
+    - name: Install GFortran macOS
+      if: contains(matrix.os, 'macos')
+      run: |
+        ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
+        which gfortran-${GCC_V}
+        which gfortran
+    - name: Install GFortran Linux
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
+        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
+    
+    - name: Install fpm
+      uses: fortran-lang/setup-fpm@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build fftpack
+      run: |
+        gfortran --version
+        fpm build --flag "-O2"
+    - name: Run tests
+      run: |
+        gfortran --version
+        fpm test --flag "-O2" tstfft


### PR DESCRIPTION
- [x] Add GitHub-CI
#### Description

I borrowed the results of certik/`minpack`'s `fpm.yml`, and added `GitHub-CI` support for `gfortran` of windows/macos/linux.

Linux/MacOS: `GFortran` version `10`;
Windows: `MingW GFortran` `8.1`.

#### Notes
> Unexpected `GFortran` version in Windows CI. (see my issue: https://github.com/fortran-lang/fpm/issues/537)

We'd better wait for the improvement of the `fpm` solution in `fpm` repo, and then decide to improve the content of `fftpack`'s GitHub-CI, currently we can keep the use of `mingw-gfortran8.1`.
